### PR TITLE
Remove references to Microsoft.CodeAnalysis

### DIFF
--- a/Generator.CSharp/Generator.CSharp.fsproj
+++ b/Generator.CSharp/Generator.CSharp.fsproj
@@ -11,7 +11,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0-1.final" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-1.final" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta2.22057.1" />
 	</ItemGroup>

--- a/Generator.Core.CSharp/Generator.Core.CSharp.fsproj
+++ b/Generator.Core.CSharp/Generator.Core.CSharp.fsproj
@@ -16,7 +16,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0-1.final" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-1.final" />
 	</ItemGroup>
 

--- a/Generator.Core.VisualBasic/Generator.Core.VisualBasic.fsproj
+++ b/Generator.Core.VisualBasic/Generator.Core.VisualBasic.fsproj
@@ -16,7 +16,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0-1.final" />
 		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.1.0-1.final" />
 	</ItemGroup>
 

--- a/Generator.Core/Generator.Core.fsproj
+++ b/Generator.Core/Generator.Core.fsproj
@@ -41,7 +41,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0-1.final" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.1.0-1.final" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/Generator.VisualBasic/Generator.VisualBasic.fsproj
+++ b/Generator.VisualBasic/Generator.VisualBasic.fsproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0-1.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.1.0-1.final" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta2.22057.1" />
 	</ItemGroup>
 

--- a/JackFruitAppModel.CSharp/JackfruitAppModel.CSharp.fsproj
+++ b/JackFruitAppModel.CSharp/JackfruitAppModel.CSharp.fsproj
@@ -26,7 +26,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0-1.final" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-1.final" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta2.22057.1" />
 	</ItemGroup>

--- a/JackFruitAppModel.VisualBasic/JackfruitAppModel.VisualBasic.fsproj
+++ b/JackFruitAppModel.VisualBasic/JackfruitAppModel.VisualBasic.fsproj
@@ -23,7 +23,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0-1.final" />
 		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.1.0-1.final" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta2.22057.1" />
 	</ItemGroup>


### PR DESCRIPTION
This package prevents the correct separation of C# and Visual Basic references.