### PR TITLE
Thoughts on customization

### DIFF
--- a/JackFruit/Dotnet.cs
+++ b/JackFruit/Dotnet.cs
@@ -52,17 +52,16 @@ namespace Jackfruit
         /// <param name="prerelease"></param>
         /// <returns></returns>
         public static int RunAddPackage(
-                                        [Description("asdfjl lkjsdf lkfj.kmsdf.kj lkjsadalfkj lasdk.f dfb")]A
+                                        [Description("asdfjl lkjsdf lkfj.kmsdf.kj lkjsadalfkj lasdk.f dfb")]
                                         FileInfo? project, 
-                                        [adfsadfas as asdf asd sdafg asdfg sdf ]
                                         [Description("asdfjl lkjsdf lkfj.kmsdf.kj lkjsadalfkj lasdk.f dfb")]
                                         string?  packageName,
                                         [Description("asdfjl lkjsdf lkfj.kmsdf.kj lkjsadalfkj lasdk.f dfb")]
                                         string? version,
                                         [Description("asdfjl lkjsdf lkfj.kmsdf.kj lkjsadalfkj lasdk.f dfb")]
-                                        [adfsadfas as asdf asd sdafg asdfg sdf] string? framework,
+                                        string? framework,
                                         bool? noRestore,
-                                        [adfsadfas as asdf asd sdafg asdfg sdf] string? source,
+                                        string? source,
                                         [Description("asdfjl lkjsdf lkfj.kmsdf.kj lkjsadalfkj lasdk.f dfb")]
                                         DirectoryInfo? packageDirectory,
                                         bool? interactive,

--- a/JackFruit/JackFruit.csproj
+++ b/JackFruit/JackFruit.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
@@ -15,10 +15,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\Generator\Generator.fsproj" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="NewFolder\" />
   </ItemGroup>
 
 </Project>

--- a/Jackfruit/CompareAppModels/MyDotnet.AppModelLib.cs
+++ b/Jackfruit/CompareAppModels/MyDotnet.AppModelLib.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace Jackfruit;
+
+//These classes are expected to be in another class lib (nuget package) that takes a dependency on JackFruit
+public interface ICustomizable<T> where T : CommandBase
+{
+    T Customize(Action<T> customizeAction);
+}
+
+public static class CustomizableExtensions
+{
+    public static T AddSubCommand<T>(this T command, Delegate codeToRun, string arctype)
+        where T : CommandBase
+    {
+        //TODO: Is this even possible to do generically?
+        return command;
+    }
+
+    public static ICustomizable<T> Customize<T>(this ICustomizable<T> commandWrapper, string archtype)
+        where T : CommandBase
+    {
+        commandWrapper.Customize(x => ParseArctype(x, archtype));
+        return commandWrapper;
+    }
+
+    private static void ParseArctype<T>(T commandBase, string archtype)
+        where T : CommandBase
+    {
+        //TODO: Parse arc-type and build up item
+    }
+}
+
+//Ideally these classes would be generated, but given they are only putting on the interface markers
+//Could consider having generator take in MSBuild properties to customize interfaces on generated classes.
+partial class DotnetCommandWrapper : ICustomizable<DotnetCommandWrapper>
+{ }
+
+partial class AddCommandWrapper : ICustomizable<AddCommandWrapper>
+{ }

--- a/Jackfruit/CompareAppModels/MyDotnet.Partial.cs
+++ b/Jackfruit/CompareAppModels/MyDotnet.Partial.cs
@@ -22,7 +22,7 @@ namespace Jackfruit
         public DotnetCommandWrapper Dotnet { get; }
     }
 
-    public class DotnetCommandWrapper : CommandBase
+    public partial class DotnetCommandWrapper : CommandBase
     {
         public Command Command { get; }
         public Option<DirectoryInfo> AdditionalprobingpathOption { get; }
@@ -68,9 +68,19 @@ namespace Jackfruit
                 RuntimeconfigOptionResult(context));
             return Task.FromResult(context.ExitCode);
         }
+
+        private Action<DotnetCommandWrapper> CustomizeAction { get; set; }
+
+        public DotnetCommandWrapper AddSubCommand(Delegate codeToRun) { return this; }
+
+        public DotnetCommandWrapper Customize(Action<DotnetCommandWrapper> customizeAction)
+        {
+            CustomizeAction = customizeAction;
+            return this;
+        }
     }
 
-    public class AddCommandWrapper : CommandBase
+    public partial class AddCommandWrapper : CommandBase
     {
         public Command Command { get; }
         public Option<DirectoryInfo> AdditionalprobingpathOption { get; }
@@ -92,9 +102,18 @@ namespace Jackfruit
         {
             return Task.FromResult(0);
         }
+
+        public AddCommandWrapper AddSubCommand(Delegate codeToRun) { return this; }
+
+
+        public AddCommandWrapper Customize(Action<AddCommandWrapper> customizeAction)
+        {
+            customizeAction?.Invoke(this);
+            return this;
+        }
     }
 
-    public class PackageCommandWrapper : CommandBase
+    public partial class PackageCommandWrapper : CommandBase
     {
         public Command Command { get; }
         public Argument<FileInfo> ProjectArgument { get; }
@@ -152,7 +171,7 @@ namespace Jackfruit
         }
     }
 
-    public class ReferenceCommandWrapper : CommandBase
+    public partial class ReferenceCommandWrapper : CommandBase
     {
         public Command Command { get; }
         public Argument<FileInfo> ProjectArgument { get; }
@@ -195,7 +214,7 @@ namespace Jackfruit
         }
     }
 
-    public class BuildCommandWrapper : CommandBase
+    public partial class BuildCommandWrapper : CommandBase
     {
         public Command Command { get; }
         public Argument<FileInfo> ProjectOrSolutionArgument { get; }
@@ -246,19 +265,19 @@ namespace Jackfruit
             Command.Handler = this;
         }
 
-       public FileInfo? ProjecOrSolutionResult(InvocationContext context) => null;
-       public bool? UseCurrentRuntimeResult(InvocationContext context) => null;
-       public string? FrameworkResult(InvocationContext context) => null;
-       public string? ConfigurationResult(InvocationContext context) => null;
-       public string? RuntimeResult(InvocationContext context) => null;
-       public string? VersionSuffixResult(InvocationContext context) => null;
-       public bool? NoRestoreResult(InvocationContext context) => null;
-       public bool? InteractiveResult(InvocationContext context) => null;
-       public Verbosity? VerbosityResult(InvocationContext context) => null;
-       public DirectoryInfo? OutputResult(InvocationContext context) => null;
-       public bool? NoIncrementalResult(InvocationContext context) => null;
-       public bool? NoDependenciesResult(InvocationContext context) => null;
-       public bool? NologoResult(InvocationContext context) => null;
+        public FileInfo? ProjecOrSolutionResult(InvocationContext context) => null;
+        public bool? UseCurrentRuntimeResult(InvocationContext context) => null;
+        public string? FrameworkResult(InvocationContext context) => null;
+        public string? ConfigurationResult(InvocationContext context) => null;
+        public string? RuntimeResult(InvocationContext context) => null;
+        public string? VersionSuffixResult(InvocationContext context) => null;
+        public bool? NoRestoreResult(InvocationContext context) => null;
+        public bool? InteractiveResult(InvocationContext context) => null;
+        public Verbosity? VerbosityResult(InvocationContext context) => null;
+        public DirectoryInfo? OutputResult(InvocationContext context) => null;
+        public bool? NoIncrementalResult(InvocationContext context) => null;
+        public bool? NoDependenciesResult(InvocationContext context) => null;
+        public bool? NologoResult(InvocationContext context) => null;
 
 
         public override Task<int> InvokeAsync(InvocationContext context)

--- a/Jackfruit/CompareAppModels/MyDotnet.cs
+++ b/Jackfruit/CompareAppModels/MyDotnet.cs
@@ -12,6 +12,42 @@ using Jackfruit;
 
 namespace Jackfruit
 {
+    public static class ExtenionPoints
+    {
+        //Moved this to an extension method for now that returned T rather than CommandBase
+        //Just to make the code compile; will need to revisit
+        public static T AddSubCommand<T>(this T command, Delegate codeToRun, string arctype)
+            where T : CommandBase
+        {
+            //TODO: Is this even possible to do generically?
+            return command;
+        }
+    }
+
+    public class Strategy4
+    {
+        public Strategy4()
+        {
+            var app = new MyApp();
+            app.AddCommand(Dotnet.RunDotnet);
+            app.Dotnet.AddSubCommand(Dotnet.RunAdd).Customize("<PROJECT>");
+            app.Dotnet.Add.AddSubCommand(Dotnet.RunAddReference).Customize("package <PACKAGE_NAME>");
+            app.Dotnet.Add.AddSubCommand(Dotnet.RunAddPackage).Customize(
+                            "<PROJECT_OR_SOLUTION>" +
+                            "--runtime <RUNTIME_IDENTIFIER>" +
+                            "--output <OUTPUT_DIR>");
+
+            app.AddCommonAliases(new List<(string alias, string optionName)>
+            { ("o", "output"),
+              ("f", "framework"),
+              ("v", "verbosity"),
+              ("n", "no-restore"),
+              ("c", "configuration"),
+              ("r", "runtime"),
+              ("i", "interactive") });
+        }
+    }
+
     public partial class MyApp : CliApp { }
 
     public class Strategy1
@@ -47,7 +83,8 @@ namespace Jackfruit
             var app = new MyApp();
             app.AddCommand(Dotnet.RunDotnet);
             app.Dotnet.AddSubCommand(Dotnet.RunAdd);
-            app.Dotnet.Add.AddSubCommand(Dotnet.RunAddReference).Customize(CustomizeAddReference);
+            app.Dotnet.Add.AddSubCommand(Dotnet.RunAddReference)
+                .Customize(CustomizeAddReference);
             app.Dotnet.Add.AddSubCommand(Dotnet.RunAddPackage);
 
             app.AddCommonAliases(new List<(string alias, string optionName)>

--- a/Jackfruit/CompareAppModels/SupportClasses.cs
+++ b/Jackfruit/CompareAppModels/SupportClasses.cs
@@ -10,8 +10,6 @@ namespace Jackfruit
 {
     public abstract class CommandBase : ICommandHandler
     {
-        public CommandBase AddSubCommand(Delegate codeToRun, string? archetype = null) { return null; }
-
         public abstract Task<int> InvokeAsync(InvocationContext context);
     }
 
@@ -33,10 +31,10 @@ namespace Jackfruit
     public enum AliasSource
     {
         Archetype = 0b_0001,  // Should archetype be included? It implies it could be entered and ignored
-        Dictionary = 0b_0010, 
+        Dictionary = 0b_0010,
         XmlComment = 0b_0100, // convention:  param name="pname"> -x | My description</param>
         Attribute = 0b_1000,
-        Lookup = 0b_0000_0001,v
+        Lookup = 0b_0000_0001,
         All = 0b1111_0001
     }
 


### PR DESCRIPTION
So, I wrote out the code I was thinking of in the meeting.

Final thoughts:
1. This did not look as good as it did in my head. 
2. I am realizing that simply having the generator put in partial methods (as you described in your README) as well as generating the classes as partials, actually gives app developers quite a bit of control. My current thinking is figuring this out is the best option.
3. I left a comment in there, that it may be nice to consider having the generator append interfaces or methods to the generated class by accepting inputs from MSBuild variables. This would give people who want to extend JackFruit even more control, and would eliminate the need for them to write Roselyn generators. A simple example is the customize method in this PR, if a library author could add a variable to include an interface on the generated classes, it would allow for extension methods on those types to be used. 